### PR TITLE
Added a doctype

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
   <head>
     <meta charset="utf-8">


### PR DESCRIPTION
Adding <!DOCTYPE html> allows jquery to properly determine the viewport size in Firefox. Before implementing this change, the app did not render properly in Firefox.
